### PR TITLE
Bypass the validation if model is not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,11 @@ module.exports = function(schema, options) {
                             } else if (typeof doc.model === 'function') {
                                 model = doc.model(doc.constructor.modelName);
                             }
-
+                            
+                            if (!model){
+                                //console.log("Cannot validate unique values in .insertMany, passing...")
+                                resolve(true);
+                            } 
                             model.where({ $and: conditions }).count(function(err, count) {
                                 resolve(count === 0);
                             });


### PR DESCRIPTION
Rather than throwing an exeption "TypeError" that will be interpreted at a validation error, if model can t be obtain, we just `resolve(true)`.